### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Easing Animation Interpolator for Android. Just more Interpolators can be used.
 
 Inspired by [AnimationEasingFunctions](https://github.com/daimajia/AnimationEasingFunctions) and [Easing Functions](http://easings.net/). Convert the Easing Functions into Android Interpolators so that you can use them more easily.
 
-##Demo
+## Demo
 ![](./.idea/ease.gif)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
